### PR TITLE
Link correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you want to contribute to a project and make it better, your help is very wel
 <strong> CSS</strong>
 </summary>
     <ul>
-        <li><a href="css-tricks.com">CSS tricks </a></li>
+        <li><a href="https://css-tricks.com">CSS tricks </a></li>
         <li><a href="https://cssreference.io"> CSS Reference</a></li>
         <li><a href="https://cssportal.com">CSS Portal</a></li>
         <li><a href="https://enjoycss.com">Enjoy CSS</a></li>


### PR DESCRIPTION
## What does this PR do?
Invalid link correction of CSS tricks website. Which helps user to reach out <kbd>[CSS-tricks](https://CSS-tricks.com)</kbd> website.
##  Description of Task to be completed?
I used `https://` before `css-tricks.com`
## How can this be manually tested?
By visiting the website through the changed link.


